### PR TITLE
Add license tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
     url='https://github.com/jeradM/pyxeoma',
     download_url='https://github.com/jeradM/pyxeoma/archive/1.4.1.tar.gz',
     keywords=['Xeoma'],
+    license='MIT',
     install_requires=[
         'aiohttp'
     ],


### PR DESCRIPTION
This allows third-party tools like PyPI or `pyp2rpm` to get the license details in a simple way.